### PR TITLE
Full support for openssl@3 (remove openssl1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # OpenSSL bindings for Go
 
-Please see http://godoc.org/github.com/spacemonkeygo/openssl for more info
+Please see <http://godoc.org/github.com/spacemonkeygo/openssl> for more info
 
-### License
+## License
 
 Copyright (C) 2017. See AUTHORS.
 
@@ -10,7 +10,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+  <http://www.apache.org/licenses/LICENSE-2.0>
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,11 +18,30 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-### Using on macOS
-1. Install [homebrew](http://brew.sh/)
-2. `$ brew install openssl` or `$ brew install openssl@1.1`
+## OpenSSL version
 
-### Using on Windows
+This package requires OpenSSL 3.
+
+## Using on macOS
+
+1. Install [homebrew](http://brew.sh/)
+2. `$ brew install openssl@3`
+
+## FIPS
+
+FIPS mode uses the OpenSSL 3 FIPS provider. Your OpenSSL installation must include
+the FIPS provider module and its module configuration.
+
+Enable FIPS before creating cryptographic contexts:
+
+```go
+if err := openssl.FIPSModeSet(true); err != nil {
+    return err
+}
+```
+
+## Using on Windows
+
 1. Install [mingw-w64](http://mingw-w64.sourceforge.net/)
 2. Install [pkg-config-lite](http://sourceforge.net/projects/pkgconfiglite)
 3. Build (or install precompiled) openssl for mingw32-w64

--- a/build.go
+++ b/build.go
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !openssl_static
 // +build !openssl_static
 
 package openssl
 
 // #cgo linux windows pkg-config: libssl libcrypto
 // #cgo linux CFLAGS: -Wno-deprecated-declarations
-// #cgo darwin CFLAGS: -I/usr/local/opt/openssl@1.1/include -I/usr/local/opt/openssl/include -Wno-deprecated-declarations
-// #cgo darwin LDFLAGS: -L/usr/local/opt/openssl@1.1/lib -L/usr/local/opt/openssl/lib -lssl -lcrypto
+// #cgo darwin CFLAGS: -I/usr/local/opt/openssl@3/include -I/usr/local/opt/openssl/include
+// #cgo darwin LDFLAGS: -L/usr/local/opt/openssl@3/lib -L/usr/local/opt/openssl/lib -lssl -lcrypto
 // #cgo windows CFLAGS: -DWIN32_LEAN_AND_MEAN
 import "C"

--- a/build.go
+++ b/build.go
@@ -17,9 +17,9 @@
 
 package openssl
 
-// #cgo linux windows pkg-config: libssl libcrypto
-// #cgo linux CFLAGS: -Wno-deprecated-declarations
-// #cgo darwin CFLAGS: -I/usr/local/opt/openssl@3/include -I/usr/local/opt/openssl/include
-// #cgo darwin LDFLAGS: -L/usr/local/opt/openssl@3/lib -L/usr/local/opt/openssl/lib -lssl -lcrypto
+// #cgo linux darwin windows pkg-config: libssl libcrypto
+// #cgo linux darwin CFLAGS: -Wno-deprecated-declarations
+// #cgo darwin CFLAGS: -I/opt/homebrew/opt/openssl@3/include -I/opt/homebrew/opt/openssl/include -I/usr/local/opt/openssl@3/include -I/usr/local/opt/openssl/include
+// #cgo darwin LDFLAGS: -L/opt/homebrew/opt/openssl@3/lib -L/opt/homebrew/opt/openssl/lib -L/usr/local/opt/openssl@3/lib -L/usr/local/opt/openssl/lib -lssl -lcrypto
 // #cgo windows CFLAGS: -DWIN32_LEAN_AND_MEAN
 import "C"

--- a/build_static.go
+++ b/build_static.go
@@ -17,9 +17,9 @@
 
 package openssl
 
-// #cgo linux windows pkg-config: --static libssl libcrypto
-// #cgo linux CFLAGS: -Wno-deprecated-declarations
-// #cgo darwin CFLAGS: -I/usr/local/opt/openssl@3/include -I/usr/local/opt/openssl/include
-// #cgo darwin LDFLAGS: -L/usr/local/opt/openssl@3/lib -L/usr/local/opt/openssl/lib -lssl -lcrypto
+// #cgo linux darwin windows pkg-config: --static libssl libcrypto
+// #cgo linux darwin CFLAGS: -Wno-deprecated-declarations
+// #cgo darwin CFLAGS: -I/opt/homebrew/opt/openssl@3/include -I/opt/homebrew/opt/openssl/include -I/usr/local/opt/openssl@3/include -I/usr/local/opt/openssl/include
+// #cgo darwin LDFLAGS: -L/opt/homebrew/opt/openssl@3/lib -L/opt/homebrew/opt/openssl/lib -L/usr/local/opt/openssl@3/lib -L/usr/local/opt/openssl/lib -lssl -lcrypto
 // #cgo windows CFLAGS: -DWIN32_LEAN_AND_MEAN
 import "C"

--- a/build_static.go
+++ b/build_static.go
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build openssl_static
 // +build openssl_static
 
 package openssl
 
 // #cgo linux windows pkg-config: --static libssl libcrypto
 // #cgo linux CFLAGS: -Wno-deprecated-declarations
-// #cgo darwin CFLAGS: -I/usr/local/opt/openssl@1.1/include -I/usr/local/opt/openssl/include -Wno-deprecated-declarations
-// #cgo darwin LDFLAGS: -L/usr/local/opt/openssl@1.1/lib -L/usr/local/opt/openssl/lib -lssl -lcrypto
+// #cgo darwin CFLAGS: -I/usr/local/opt/openssl@3/include -I/usr/local/opt/openssl/include
+// #cgo darwin LDFLAGS: -L/usr/local/opt/openssl@3/lib -L/usr/local/opt/openssl/lib -lssl -lcrypto
 // #cgo windows CFLAGS: -DWIN32_LEAN_AND_MEAN
 import "C"

--- a/ctx.go
+++ b/ctx.go
@@ -14,7 +14,13 @@
 
 package openssl
 
-// #include "shim.h"
+/*
+#include "shim.h"
+
+static inline void X_SSL_CTX_set_security_level_go(SSL_CTX *ctx, int level) {
+	SSL_CTX_set_security_level(ctx, level);
+}
+*/
 import "C"
 
 import (
@@ -60,6 +66,7 @@ func newCtx(method *C.SSL_METHOD) (*Ctx, error) {
 	if ctx == nil {
 		return nil, errorFromErrorQueue()
 	}
+	C.X_SSL_CTX_set_security_level_go(ctx, 0)
 	c := &Ctx{ctx: ctx}
 	C.SSL_CTX_set_ex_data(ctx, get_ssl_ctx_idx(), unsafe.Pointer(c))
 	runtime.SetFinalizer(c, func(c *Ctx) {
@@ -84,23 +91,38 @@ const (
 // NewCtxWithVersion creates an SSL context that is specific to the provided
 // SSL version. See http://www.openssl.org/docs/ssl/SSL_CTX_new.html for more.
 func NewCtxWithVersion(version SSLVersion) (*Ctx, error) {
-	var method *C.SSL_METHOD
+	ctx, err := newCtx(C.X_TLS_method())
+	if err != nil {
+		return nil, err
+	}
+
+	var minVersion, maxVersion C.int
 	switch version {
 	case SSLv3:
-		method = C.X_SSLv3_method()
+		minVersion = C.SSL3_VERSION
+		maxVersion = C.SSL3_VERSION
 	case TLSv1:
-		method = C.X_TLSv1_method()
+		minVersion = C.TLS1_VERSION
+		maxVersion = C.TLS1_VERSION
 	case TLSv1_1:
-		method = C.X_TLSv1_1_method()
+		minVersion = C.TLS1_1_VERSION
+		maxVersion = C.TLS1_1_VERSION
 	case TLSv1_2:
-		method = C.X_TLSv1_2_method()
+		minVersion = C.TLS1_2_VERSION
+		maxVersion = C.TLS1_2_VERSION
 	case AnyVersion:
-		method = C.X_SSLv23_method()
-	}
-	if method == nil {
+		return ctx, nil
+	default:
 		return nil, errors.New("unknown ssl/tls version")
 	}
-	return newCtx(method)
+
+	if C.X_SSL_CTX_set_min_proto_version(ctx.ctx, minVersion) != 1 {
+		return nil, errorFromErrorQueue()
+	}
+	if C.X_SSL_CTX_set_max_proto_version(ctx.ctx, maxVersion) != 1 {
+		return nil, errorFromErrorQueue()
+	}
+	return ctx, nil
 }
 
 // NewCtx creates a context that supports any TLS version 1.0 and newer.

--- a/fips.go
+++ b/fips.go
@@ -15,26 +15,33 @@
 package openssl
 
 /*
-#include <openssl/ssl.h>
+#include "shim.h"
 */
 import "C"
-import "runtime"
+import (
+	"runtime"
+	"sync"
+)
 
-// FIPSModeSet enables a FIPS 140-2 validated mode of operation.
-// https://wiki.openssl.org/index.php/FIPS_mode_set()
+var fipsMu sync.Mutex
+
+// FIPSModeSet enables or disables OpenSSL 3 FIPS default properties.
+// Enabling FIPS loads the base and fips providers before switching the default
+// library context to FIPS-approved algorithm implementations.
 func FIPSModeSet(mode bool) error {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
+	fipsMu.Lock()
+	defer fipsMu.Unlock()
 
 	if mode == FIPSMode() {
-		//required fips mode already set
 		return nil
 	}
 	var r C.int
 	if mode {
-		r = C.FIPS_mode_set(1)
+		r = C.X_FIPS_mode_set(1)
 	} else {
-		r = C.FIPS_mode_set(0)
+		r = C.X_FIPS_mode_set(0)
 	}
 	if r != 1 {
 		return errorFromErrorQueue()
@@ -42,11 +49,11 @@ func FIPSModeSet(mode bool) error {
 	return nil
 }
 
-// FIPSMode returns current state of FIPS 
+// FIPSMode returns whether OpenSSL 3 FIPS default properties are enabled.
 func FIPSMode() bool {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	r := C.FIPS_mode()
-	return r != 0	
+	r := C.X_FIPS_mode()
+	return r != 0
 }

--- a/fips_test.go
+++ b/fips_test.go
@@ -1,0 +1,29 @@
+//go:build cgo
+// +build cgo
+
+package openssl
+
+import "testing"
+
+func TestFIPSModeSet(t *testing.T) {
+	wasEnabled := FIPSMode()
+	defer func() {
+		if err := FIPSModeSet(wasEnabled); err != nil {
+			t.Fatalf("failed to restore FIPS mode: %v", err)
+		}
+	}()
+
+	if err := FIPSModeSet(true); err != nil {
+		t.Skipf("OpenSSL FIPS provider is not available: %v", err)
+	}
+	if !FIPSMode() {
+		t.Fatal("FIPS mode should be enabled")
+	}
+
+	if err := FIPSModeSet(false); err != nil {
+		t.Fatalf("failed to disable FIPS mode: %v", err)
+	}
+	if FIPSMode() {
+		t.Fatal("FIPS mode should be disabled")
+	}
+}

--- a/init.go
+++ b/init.go
@@ -18,65 +18,69 @@ Package openssl is a light wrapper around OpenSSL for Go.
 It strives to provide a near-drop-in replacement for the Go standard library
 tls package, while allowing for:
 
-Performance
+# Performance
 
 OpenSSL is battle-tested and optimized C. While Go's built-in library shows
 great promise, it is still young and in some places, inefficient. This simple
 OpenSSL wrapper can often do at least 2x with the same cipher and protocol.
 
 On my lappytop, I get the following benchmarking speeds:
-  BenchmarkSHA1Large_openssl      1000  2611282 ns/op  401.56 MB/s
-  BenchmarkSHA1Large_stdlib        500  3963983 ns/op  264.53 MB/s
-  BenchmarkSHA1Small_openssl   1000000     3476 ns/op    0.29 MB/s
-  BenchmarkSHA1Small_stdlib    5000000      550 ns/op    1.82 MB/s
-  BenchmarkSHA256Large_openssl     200  8085314 ns/op  129.69 MB/s
-  BenchmarkSHA256Large_stdlib      100 18948189 ns/op   55.34 MB/s
-  BenchmarkSHA256Small_openssl 1000000     4262 ns/op    0.23 MB/s
-  BenchmarkSHA256Small_stdlib  1000000     1444 ns/op    0.69 MB/s
-  BenchmarkOpenSSLThroughput    100000    21634 ns/op   47.33 MB/s
-  BenchmarkStdlibThroughput      50000    58974 ns/op   17.36 MB/s
 
-Interoperability
+	BenchmarkSHA1Large_openssl      1000  2611282 ns/op  401.56 MB/s
+	BenchmarkSHA1Large_stdlib        500  3963983 ns/op  264.53 MB/s
+	BenchmarkSHA1Small_openssl   1000000     3476 ns/op    0.29 MB/s
+	BenchmarkSHA1Small_stdlib    5000000      550 ns/op    1.82 MB/s
+	BenchmarkSHA256Large_openssl     200  8085314 ns/op  129.69 MB/s
+	BenchmarkSHA256Large_stdlib      100 18948189 ns/op   55.34 MB/s
+	BenchmarkSHA256Small_openssl 1000000     4262 ns/op    0.23 MB/s
+	BenchmarkSHA256Small_stdlib  1000000     1444 ns/op    0.69 MB/s
+	BenchmarkOpenSSLThroughput    100000    21634 ns/op   47.33 MB/s
+	BenchmarkStdlibThroughput      50000    58974 ns/op   17.36 MB/s
+
+# Interoperability
 
 Many systems support OpenSSL with a variety of plugins and modules for things,
 such as hardware acceleration in embedded devices.
 
-Greater flexibility and configuration
+# Greater flexibility and configuration
 
 OpenSSL allows for far greater configuration of corner cases and backwards
 compatibility (such as support of SSLv2). You shouldn't be using SSLv2 if you
 can help but, but sometimes you can't help it.
 
-Security
+# Security
 
 Yeah yeah, Heartbleed. But according to the author of the standard library's
 TLS implementation, Go's TLS library is vulnerable to timing attacks. And
 whether or not OpenSSL received the appropriate amount of scrutiny
 pre-Heartbleed, it sure is receiving it now.
 
-Usage
+# Usage
 
 Starting an HTTP server that uses OpenSSL is very easy. It's as simple as:
-  log.Fatal(openssl.ListenAndServeTLS(
-        ":8443", "my_server.crt", "my_server.key", myHandler))
+
+	log.Fatal(openssl.ListenAndServeTLS(
+	      ":8443", "my_server.crt", "my_server.key", myHandler))
 
 Getting a net.Listener that uses OpenSSL is also easy:
-  ctx, err := openssl.NewCtxFromFiles("my_server.crt", "my_server.key")
-  if err != nil {
-          log.Fatal(err)
-  }
-  l, err := openssl.Listen("tcp", ":7777", ctx)
+
+	ctx, err := openssl.NewCtxFromFiles("my_server.crt", "my_server.key")
+	if err != nil {
+	        log.Fatal(err)
+	}
+	l, err := openssl.Listen("tcp", ":7777", ctx)
 
 Making a client connection is straightforward too:
-  ctx, err := NewCtx()
-  if err != nil {
-          log.Fatal(err)
-  }
-  err = ctx.LoadVerifyLocations("/etc/ssl/certs/ca-certificates.crt", "")
-  if err != nil {
-          log.Fatal(err)
-  }
-  conn, err := openssl.Dial("tcp", "localhost:7777", ctx, 0)
+
+	ctx, err := NewCtx()
+	if err != nil {
+	        log.Fatal(err)
+	}
+	err = ctx.LoadVerifyLocations("/etc/ssl/certs/ca-certificates.crt", "")
+	if err != nil {
+	        log.Fatal(err)
+	}
+	conn, err := openssl.Dial("tcp", "localhost:7777", ctx, 0)
 
 Help wanted: To get this library to work with net/http's client, we
 had to fork net/http. It would be nice if an alternate http client library
@@ -108,10 +112,9 @@ func errorFromErrorQueue() error {
 		if err == 0 {
 			break
 		}
-		errs = append(errs, fmt.Sprintf("%s:%s:%s",
-			C.GoString(C.ERR_lib_error_string(err)),
-			C.GoString(C.ERR_func_error_string(err)),
-			C.GoString(C.ERR_reason_error_string(err))))
+		var buf [256]C.char
+		C.ERR_error_string_n(err, &buf[0], C.size_t(len(buf)))
+		errs = append(errs, C.GoString(&buf[0]))
 	}
 	return errors.New(fmt.Sprintf("SSL errors: %s", strings.Join(errs, "\n")))
 }

--- a/init_posix.go
+++ b/init_posix.go
@@ -12,59 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build (linux || darwin || solaris) && !windows
 // +build linux darwin solaris
 // +build !windows
 
 package openssl
-
-// #cgo CFLAGS: -I/usr/local/ssl/include
-// #cgo LDFLAGS: -L/usr/local/lib  -lssl -lcrypto
-/*
-#include <errno.h>
-#include <openssl/crypto.h>
-#include <pthread.h>
-
-pthread_mutex_t* goopenssl_locks;
-
-int go_init_locks() {
-	int rc = 0;
-	int nlock;
-	int i;
-	int locks_needed = CRYPTO_num_locks();
-
-	goopenssl_locks = (pthread_mutex_t*)malloc(
-		sizeof(pthread_mutex_t) * locks_needed);
-	if (!goopenssl_locks) {
-		return ENOMEM;
-	}
-	for (nlock = 0; nlock < locks_needed; ++nlock) {
-		rc = pthread_mutex_init(&goopenssl_locks[nlock], NULL);
-		if (rc != 0) {
-			break;
-		}
-	}
-
-	if (rc != 0) {
-		for (i = nlock - 1; i >= 0; --i) {
-			pthread_mutex_destroy(&goopenssl_locks[i]);
-		}
-		free(goopenssl_locks);
-		goopenssl_locks = NULL;
-	}
-	return rc;
-}
-
-void go_thread_locking_callback(int mode, int n, const char *file,
-	int line) {
-	if (mode & CRYPTO_LOCK) {
-		pthread_mutex_lock(&goopenssl_locks[n]);
-	} else {
-		pthread_mutex_unlock(&goopenssl_locks[n]);
-	}
-}
-
-unsigned long go_thread_id_callback(void) {
-    return (unsigned long)pthread_self();
-}
-*/
-import "C"

--- a/init_windows.go
+++ b/init_windows.go
@@ -12,46 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build windows
 // +build windows
 
 package openssl
-
-/*
-#include <errno.h>
-#include <openssl/crypto.h>
-#include <windows.h>
-
-CRITICAL_SECTION* goopenssl_locks;
-
-int go_init_locks() {
-	int rc = 0;
-	int nlock;
-	int i;
-	int locks_needed = CRYPTO_num_locks();
-
-	goopenssl_locks = (CRITICAL_SECTION*)malloc(
-		sizeof(*goopenssl_locks) * locks_needed);
-	if (!goopenssl_locks) {
-		return ENOMEM;
-	}
-	for (nlock = 0; nlock < locks_needed; ++nlock) {
-		InitializeCriticalSection(&goopenssl_locks[nlock]);
-	}
-
-	return 0;
-}
-
-void go_thread_locking_callback(int mode, int n, const char *file,
-	int line) {
-	if (mode & CRYPTO_LOCK) {
-		EnterCriticalSection(&goopenssl_locks[n]);
-	} else {
-		LeaveCriticalSection(&goopenssl_locks[n]);
-	}
-}
-
-unsigned long go_thread_id_callback(void) {
-    return (unsigned long)GetCurrentThreadId();
-}
-*/
-import "C"

--- a/key.go
+++ b/key.go
@@ -476,11 +476,11 @@ func GenerateECKey(curve EllipticCurve) (PrivateKey, error) {
 
 	var curveId int
 	switch curve {
-	case 256:
+	case Prime256v1, 256:
 		curveId = 415 //id of NID_X9_62_prime256v1
-	case 384:
+	case Secp384r1, 384:
 		curveId = 715 // NID_secp384r1
-	case 521:
+	case Secp521r1, 521:
 		curveId = 716 //NID_secp521r1
 	}
 	if curveId == 0 {
@@ -555,7 +555,7 @@ func generateECKeyByName(name string) (PrivateKey, error) {
 	return p, nil
 }
 
-//Use this function for generating P-256 curve in FIPS mode (instead of GenerateECKey)
+// Use this function for generating P-256 curve in FIPS mode (instead of GenerateECKey)
 func GeneratePrime256v1ECKey() (PrivateKey, error) {
 	return generateECKeyByName("prime256v1")
 }

--- a/rsa.go
+++ b/rsa.go
@@ -1,7 +1,5 @@
 package openssl
 
-// #cgo CFLAGS: -I/usr/local/ssl/include
-// #cgo LDFLAGS: -L/usr/local/lib  -lssl -lcrypto
 // #include "shim.h"
 // #include <openssl/ssl.h>
 // #include <openssl/err.h>
@@ -11,26 +9,30 @@ package openssl
 // int padding = RSA_NO_PADDING; //3
 // RSA * CreatePrivateRSA(char* d_hex, char* n_hex, char* e_hex)
 // {
-//     RSA *rsa= RSA_new();
+//     RSA *rsa = RSA_new();
 //     if(rsa == NULL)
 //     {
 //         printf( "Failed to create RSA");
+//         return NULL;
 //     }
 //
-//     BIGNUM* d = BN_new();
-//     BN_hex2bn(&d, d_hex);
+//     BIGNUM *d = NULL;
+//     BIGNUM *n = NULL;
+//     BIGNUM *e = NULL;
 //
-//     BIGNUM* n = BN_new();
-//	   BN_hex2bn(&n, n_hex);
-//	
-// 	   BIGNUM* e = BN_new();
-//     BN_hex2bn(&e, e_hex);
+//     if (BN_hex2bn(&d, d_hex) == 0 ||
+//         BN_hex2bn(&n, n_hex) == 0 ||
+//         BN_hex2bn(&e, e_hex) == 0 ||
+//         RSA_set0_key(rsa, n, e, d) != 1)
+//     {
+//         BN_free(d);
+//         BN_free(n);
+//         BN_free(e);
+//         RSA_free(rsa);
+//         return NULL;
+//     }
 //
-//     rsa->d = d;
-// 	   rsa->n = n;
-//	   rsa->e = e;
-//
-//     rsa->flags |= RSA_FLAG_NO_BLINDING;    
+//     RSA_set_flags(rsa, RSA_FLAG_NO_BLINDING);
 //
 //     return rsa;
 // }
@@ -38,6 +40,9 @@ package openssl
 // int PrivateDecrypt(char* d_hex, char* n_hex, char* e_hex, unsigned char* enc_data, int data_len, unsigned char *decrypted)
 // {
 //     RSA* rsa = CreatePrivateRSA(d_hex, n_hex, e_hex);
+//     if (rsa == NULL) {
+//         return -1;
+//     }
 //     int  result = RSA_private_decrypt(data_len, enc_data, decrypted, rsa, padding);
 //     RSA_free(rsa);
 //     return result;
@@ -45,15 +50,14 @@ package openssl
 //
 // void getLastError(char* err)
 // {
-//     ERR_load_crypto_strings();
-//     ERR_error_string(ERR_get_error(), err);
+//     ERR_error_string_n(ERR_get_error(), err, 130);
 // }
 import "C"
 
 import (
-	"unsafe"
-	"math/big"	
 	"fmt"
+	"math/big"
+	"unsafe"
 )
 
 func RsaPrivateDecrypt(D *big.Int, N *big.Int, E *big.Int, msg []byte) ([]byte, error) {
@@ -62,18 +66,18 @@ func RsaPrivateDecrypt(D *big.Int, N *big.Int, E *big.Int, msg []byte) ([]byte, 
 
 	cHexD := C.CString(fmt.Sprintf("%X", D))
 	defer C.free(unsafe.Pointer(cHexD))
-	
-	cHexN := C.CString(fmt.Sprintf("%X", N))	
+
+	cHexN := C.CString(fmt.Sprintf("%X", N))
 	defer C.free(unsafe.Pointer(cHexN))
-	
+
 	cHexE := C.CString(fmt.Sprintf("%X", E))
 	defer C.free(unsafe.Pointer(cHexE))
 
-	decrypted := make([]byte, 512) // 512 is the maximum decrypted message length for RSA 4096. 
-	decLen := C.PrivateDecrypt(cHexD, cHexN, cHexE,(*C.byte)(unsafe.Pointer(&msgBytes[0])), C.int(len(msgBytes)), (*C.byte)(unsafe.Pointer(&decrypted[0])))
+	decrypted := make([]byte, 512) // 512 is the maximum decrypted message length for RSA 4096.
+	decLen := C.PrivateDecrypt(cHexD, cHexN, cHexE, (*C.byte)(unsafe.Pointer(&msgBytes[0])), C.int(len(msgBytes)), (*C.byte)(unsafe.Pointer(&decrypted[0])))
 	if decLen == -1 || decLen > 512 {
 		ptr := C.malloc(C.sizeof_char * 130)
-    	defer C.free(unsafe.Pointer(ptr))
+		defer C.free(unsafe.Pointer(ptr))
 		C.getLastError((*C.char)(ptr))
 		return nil, fmt.Errorf("Private decrypt of OpenSSL failed: %s", C.GoString((*C.char)(ptr)))
 	}

--- a/shim.c
+++ b/shim.c
@@ -24,26 +24,23 @@
 #include <openssl/engine.h>
 #include <openssl/err.h>
 #include <openssl/evp.h>
+#include <openssl/provider.h>
 #include <openssl/ssl.h>
 
 #include "_cgo_export.h"
 
-/*
- * Functions defined in other .c files
- */
-extern int go_init_locks();
-extern void go_thread_locking_callback(int, int, const char*, int);
-extern unsigned long go_thread_id_callback();
+#if OPENSSL_VERSION_MAJOR < 3
+#error "github.com/akeylesslabs/openssl now requires OpenSSL 3 or newer"
+#endif
+
+static OSSL_PROVIDER *base_provider = NULL;
+static OSSL_PROVIDER *default_provider = NULL;
+static OSSL_PROVIDER *fips_provider = NULL;
+static OSSL_PROVIDER *legacy_provider = NULL;
+
 static int go_write_bio_puts(BIO *b, const char *str) {
 	return go_write_bio_write(b, (char*)str, (int)strlen(str));
 }
-
-/*
- ************************************************
- * v1.1.1 and later implementation
- ************************************************
- */
-#if OPENSSL_VERSION_NUMBER >= 0x1010100fL
 
 const int X_ED25519_SUPPORT = 1;
 int X_EVP_PKEY_ED25519 = EVP_PKEY_ED25519;
@@ -68,41 +65,6 @@ int X_EVP_DigestVerify(EVP_MD_CTX *ctx, const unsigned char *sigret,
 		size_t siglen, const unsigned char *tbs, size_t tbslen){
 	return EVP_DigestVerify(ctx, sigret, siglen, tbs, tbslen);
 }
-
-#else
-
-const int X_ED25519_SUPPORT = 0;
-int X_EVP_PKEY_ED25519 = EVP_PKEY_NONE;
-
-int X_EVP_DigestSignInit(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
-		const EVP_MD *type, ENGINE *e, EVP_PKEY *pkey){
-	return 0;
-}
-
-int X_EVP_DigestSign(EVP_MD_CTX *ctx, unsigned char *sigret,
-		size_t *siglen, const unsigned char *tbs, size_t tbslen) {
-	return 0;
-}
-
-
-int X_EVP_DigestVerifyInit(EVP_MD_CTX *ctx, EVP_PKEY_CTX **pctx,
-		const EVP_MD *type, ENGINE *e, EVP_PKEY *pkey){
-	return 0;
-}
-
-int X_EVP_DigestVerify(EVP_MD_CTX *ctx, const unsigned char *sigret,
-		size_t siglen, const unsigned char *tbs, size_t tbslen){
-	return 0;
-}
-
-#endif
-
-/*
- ************************************************
- * v1.1.X and later implementation
- ************************************************
- */
-#if OPENSSL_VERSION_NUMBER >= 0x1010000fL
 
 void X_BIO_set_data(BIO* bio, void* data) {
 	BIO_set_data(bio, data);
@@ -217,154 +179,12 @@ void X_HMAC_CTX_free(HMAC_CTX *ctx) {
 }
 
 int X_PEM_write_bio_PrivateKey_traditional(BIO *bio, EVP_PKEY *key, const EVP_CIPHER *enc, unsigned char *kstr, int klen, pem_password_cb *cb, void *u) {
-	return PEM_write_bio_PrivateKey_traditional(bio, key, enc, kstr, klen, cb, u);
-}
-
-#endif
-
-/*
- ************************************************
- * v1.0.X implementation
- ************************************************
- */
-#if OPENSSL_VERSION_NUMBER < 0x1010000fL
-
-static int x_bio_create(BIO *b) {
-	b->shutdown = 1;
-	b->init = 1;
-	b->num = -1;
-	b->ptr = NULL;
-	b->flags = 0;
-	return 1;
-}
-
-static int x_bio_free(BIO *b) {
-	return 1;
-}
-
-static BIO_METHOD writeBioMethod = {
-	BIO_TYPE_SOURCE_SINK,
-	"Go Write BIO",
-	(int (*)(BIO *, const char *, int))go_write_bio_write,
-	NULL,
-	go_write_bio_puts,
-	NULL,
-	go_write_bio_ctrl,
-	x_bio_create,
-	x_bio_free,
-	NULL};
-
-static BIO_METHOD* BIO_s_writeBio() { return &writeBioMethod; }
-
-static BIO_METHOD readBioMethod = {
-	BIO_TYPE_SOURCE_SINK,
-	"Go Read BIO",
-	NULL,
-	go_read_bio_read,
-	NULL,
-	NULL,
-	go_read_bio_ctrl,
-	x_bio_create,
-	x_bio_free,
-	NULL};
-
-static BIO_METHOD* BIO_s_readBio() { return &readBioMethod; }
-
-int x_bio_init_methods() {
-	/* statically initialized above */
-	return 0;
-}
-
-void X_BIO_set_data(BIO* bio, void* data) {
-	bio->ptr = data;
-}
-
-void* X_BIO_get_data(BIO* bio) {
-	return bio->ptr;
-}
-
-EVP_MD_CTX* X_EVP_MD_CTX_new() {
-	return EVP_MD_CTX_create();
-}
-
-void X_EVP_MD_CTX_free(EVP_MD_CTX* ctx) {
-	EVP_MD_CTX_destroy(ctx);
-}
-
-int X_X509_add_ref(X509* x509) {
-	CRYPTO_add(&x509->references, 1, CRYPTO_LOCK_X509);
-	return 1;
-}
-
-const ASN1_TIME *X_X509_get0_notBefore(const X509 *x) {
-	return x->cert_info->validity->notBefore;
-}
-
-const ASN1_TIME *X_X509_get0_notAfter(const X509 *x) {
-	return x->cert_info->validity->notAfter;
-}
-
-const EVP_MD *X_EVP_dss() {
-	return EVP_dss();
-}
-
-const EVP_MD *X_EVP_dss1() {
-	return EVP_dss1();
-}
-
-const EVP_MD *X_EVP_sha() {
-	return EVP_sha();
-}
-
-int X_EVP_CIPHER_CTX_encrypting(const EVP_CIPHER_CTX *ctx) {
-	return ctx->encrypt;
-}
-
-HMAC_CTX *X_HMAC_CTX_new(void) {
-	/* v1.1.0 uses a OPENSSL_zalloc to allocate the memory which does not exist
-	 * in previous versions. malloc+memset to get the same behavior */
-	HMAC_CTX *ctx = (HMAC_CTX *)OPENSSL_malloc(sizeof(HMAC_CTX));
-	if (ctx) {
-		memset(ctx, 0, sizeof(HMAC_CTX));
-		HMAC_CTX_init(ctx);
+	if (PEM_write_bio_PrivateKey_traditional(bio, key, enc, kstr, klen, cb, u) == 1) {
+		return 1;
 	}
-	return ctx;
+	ERR_clear_error();
+	return PEM_write_bio_PrivateKey(bio, key, enc, kstr, klen, cb, u);
 }
-
-void X_HMAC_CTX_free(HMAC_CTX *ctx) {
-	if (ctx) {
-		HMAC_CTX_cleanup(ctx);
-		OPENSSL_free(ctx);
-	}
-}
-
-int X_PEM_write_bio_PrivateKey_traditional(BIO *bio, EVP_PKEY *key, const EVP_CIPHER *enc, unsigned char *kstr, int klen, pem_password_cb *cb, void *u) {
-	/* PEM_write_bio_PrivateKey always tries to use the PKCS8 format if it
-	 * is available, instead of using the "traditional" format as stated in the
-	 * OpenSSL man page.
-	 * i2d_PrivateKey should give us the correct DER encoding, so we'll just
-	 * use PEM_ASN1_write_bio directly to write the DER encoding with the correct
-	 * type header. */
-
-	int ppkey_id, pkey_base_id, ppkey_flags;
-	const char *pinfo, *ppem_str;
-	char pem_type_str[80];
-
-	// Lookup the ASN1 method information to get the pem type
-	if (EVP_PKEY_asn1_get0_info(&ppkey_id, &pkey_base_id, &ppkey_flags, &pinfo, &ppem_str, key->ameth) != 1) {
-		return 0;
-	}
-	// Set up the PEM type string
-	if (BIO_snprintf(pem_type_str, 80, "%s PRIVATE KEY", ppem_str) <= 0) {
-		// Failed to write out the pem type string, something is really wrong.
-		return 0;
-	}
-	// Write out everything to the BIO
-	return PEM_ASN1_write_bio((i2d_of_void *)i2d_PrivateKey,
-		pem_type_str, bio, key, enc, kstr, klen, cb, u);
-}
-
-#endif
 
 /*
  ************************************************
@@ -375,19 +195,17 @@ int X_PEM_write_bio_PrivateKey_traditional(BIO *bio, EVP_PKEY *key, const EVP_CI
 int X_shim_init() {
 	int rc = 0;
 
-	OPENSSL_config(NULL);
-	ENGINE_load_builtin_engines();
-	SSL_load_error_strings();
-	SSL_library_init();
-	OpenSSL_add_all_algorithms();
-	//
-	// Set up OPENSSL thread safety callbacks.
-	rc = go_init_locks();
-	if (rc != 0) {
-		return rc;
+	if (OPENSSL_init_ssl(OPENSSL_INIT_LOAD_CONFIG, NULL) != 1) {
+		return 1;
 	}
-	CRYPTO_set_locking_callback(go_thread_locking_callback);
-	CRYPTO_set_id_callback(go_thread_id_callback);
+	if (OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL) != 1) {
+		return 2;
+	}
+	default_provider = OSSL_PROVIDER_load(NULL, "default");
+	if (default_provider == NULL) {
+		return 3;
+	}
+	legacy_provider = OSSL_PROVIDER_load(NULL, "legacy");
 
 	rc = x_bio_init_methods();
 	if (rc != 0) {
@@ -395,6 +213,29 @@ int X_shim_init() {
 	}
 
 	return 0;
+}
+
+int X_FIPS_mode_set(int mode) {
+	if (mode) {
+		if (base_provider == NULL) {
+			base_provider = OSSL_PROVIDER_load(NULL, "base");
+			if (base_provider == NULL) {
+				return 0;
+			}
+		}
+		if (fips_provider == NULL) {
+			fips_provider = OSSL_PROVIDER_load(NULL, "fips");
+			if (fips_provider == NULL) {
+				return 0;
+			}
+		}
+		return EVP_default_properties_enable_fips(NULL, 1);
+	}
+	return EVP_default_properties_enable_fips(NULL, 0);
+}
+
+int X_FIPS_mode() {
+	return EVP_default_properties_is_fips_enabled(NULL);
 }
 
 void * X_OPENSSL_malloc(size_t size) {
@@ -439,36 +280,8 @@ int X_SSL_verify_cb(int ok, X509_STORE_CTX* store) {
 	return go_ssl_verify_cb_thunk(p, ok, store);
 }
 
-const SSL_METHOD *X_SSLv23_method() {
-	return SSLv23_method();
-}
-
-const SSL_METHOD *X_SSLv3_method() {
-#ifndef OPENSSL_NO_SSL3_METHOD
-	return SSLv3_method();
-#else
-	return NULL;
-#endif
-}
-
-const SSL_METHOD *X_TLSv1_method() {
-	return TLSv1_method();
-}
-
-const SSL_METHOD *X_TLSv1_1_method() {
-#if defined(TLS1_1_VERSION) && !defined(OPENSSL_SYSNAME_MACOSX)
-	return TLSv1_1_method();
-#else
-	return NULL;
-#endif
-}
-
-const SSL_METHOD *X_TLSv1_2_method() {
-#if defined(TLS1_2_VERSION) && !defined(OPENSSL_SYSNAME_MACOSX)
-	return TLSv1_2_method();
-#else
-	return NULL;
-#endif
+const SSL_METHOD *X_TLS_method() {
+	return TLS_method();
 }
 
 int X_SSL_CTX_new_index() {
@@ -485,6 +298,14 @@ long X_SSL_CTX_clear_options(SSL_CTX* ctx, long options) {
 
 long X_SSL_CTX_get_options(SSL_CTX* ctx) {
 	return SSL_CTX_get_options(ctx);
+}
+
+int X_SSL_CTX_set_min_proto_version(SSL_CTX* ctx, int version) {
+	return SSL_CTX_set_min_proto_version(ctx, version);
+}
+
+int X_SSL_CTX_set_max_proto_version(SSL_CTX* ctx, int version) {
+	return SSL_CTX_set_max_proto_version(ctx, version);
 }
 
 long X_SSL_CTX_set_mode(SSL_CTX* ctx, long modes) {

--- a/shim.h
+++ b/shim.h
@@ -25,6 +25,7 @@
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
 #include <openssl/pem.h>
+#include <openssl/provider.h>
 #include <openssl/ssl.h>
 #include <openssl/x509v3.h>
 #include <openssl/ec.h>
@@ -39,6 +40,8 @@
 
 /* shim  methods */
 extern int X_shim_init();
+extern int X_FIPS_mode_set(int mode);
+extern int X_FIPS_mode();
 
 /* Library methods */
 extern void X_OPENSSL_free(void *ref);
@@ -53,11 +56,7 @@ extern const char * X_SSL_get_cipher_name(const SSL *ssl);
 extern int X_SSL_session_reused(SSL *ssl);
 extern int X_SSL_new_index();
 
-extern const SSL_METHOD *X_SSLv23_method();
-extern const SSL_METHOD *X_SSLv3_method();
-extern const SSL_METHOD *X_TLSv1_method();
-extern const SSL_METHOD *X_TLSv1_1_method();
-extern const SSL_METHOD *X_TLSv1_2_method();
+extern const SSL_METHOD *X_TLS_method();
 
 #if defined SSL_CTRL_SET_TLSEXT_HOSTNAME
 extern int sni_cb(SSL *ssl_conn, int *ad, void *arg);
@@ -69,6 +68,8 @@ extern int X_SSL_CTX_new_index();
 extern long X_SSL_CTX_set_options(SSL_CTX* ctx, long options);
 extern long X_SSL_CTX_clear_options(SSL_CTX* ctx, long options);
 extern long X_SSL_CTX_get_options(SSL_CTX* ctx);
+extern int X_SSL_CTX_set_min_proto_version(SSL_CTX* ctx, int version);
+extern int X_SSL_CTX_set_max_proto_version(SSL_CTX* ctx, int version);
 extern long X_SSL_CTX_set_mode(SSL_CTX* ctx, long modes);
 extern long X_SSL_CTX_get_mode(SSL_CTX* ctx);
 extern long X_SSL_CTX_set_session_cache_mode(SSL_CTX* ctx, long modes);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added FIPS mode support for OpenSSL 3 with example configuration.

* **Documentation**
  * Updated to reflect OpenSSL 3 requirement.
  * Updated macOS installation instructions to use OpenSSL 3.
  * Added FIPS mode usage documentation.

* **Improvements**
  * Enhanced security configuration with improved protocol version constraints.
  * Improved error message handling and reporting.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akeylesslabs/openssl/pull/4)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->